### PR TITLE
put local-data inside a server block

### DIFF
--- a/unbound-block-hosts
+++ b/unbound-block-hosts
@@ -90,9 +90,11 @@ foreach my $line (split("\n", $res->content)) {
 	}
 }
 
+
+printf(FILE "server:\n");
 map {
-	printf(FILE "local-data: \"%s A %s\"\n", $_, $opt->{'address'});
-	printf(FILE "local-data: \"%s AAAA %s\"\n", $_, $opt->{'v6address'});
+	printf(FILE "\tlocal-data: \"%s A %s\"\n", $_, $opt->{'address'});
+	printf(FILE "\tlocal-data: \"%s AAAA %s\"\n", $_, $opt->{'v6address'});
 } @names;
 
 close(FILE);


### PR DESCRIPTION
On my unbound version (1.4.16) local-data is only valid within a server block.
