### PR TITLE
If not modified, print status message to stdout

### DIFF
--- a/unbound-block-hosts
+++ b/unbound-block-hosts
@@ -75,7 +75,11 @@ if ($res->is_error) {
 	exit(1);
 
 } elsif (!$res->is_success) {
-	printf(STDERR "(%s)\n", $res->message);
+	if ($res->code(304)) {
+		printf(STDOUT "(%s)\n", $res->message);
+	} else {
+		printf(STDERR "(%s)\n", $res->message);
+	}
 	exit;
 
 }


### PR DESCRIPTION
If a 304 is returned, print status message to STDOUT rather than STDERR.